### PR TITLE
fix showDatePicker in ios

### DIFF
--- a/DateTime.ios.js
+++ b/DateTime.ios.js
@@ -43,7 +43,7 @@ export default class DateTimePicker extends Component {
         this.setState({
             mode: 'date',
             visible: true,
-            date: new Date()
+            date: date
         });
     }
 


### PR DESCRIPTION
在IOS版本中，使用showDatePicker无法显示传入的时间，显示的永远都是当前时间。
