### PR TITLE
change example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ var {
     Text,
 } = React;
 
-var DateTimePicker = require('react-native-datetime');
+var DateTimePicker = require('react-native-datetime').default;
 var Button = require('@remobile/react-native-simple-button');
 
 module.exports = React.createClass({


### PR DESCRIPTION
use the default example, in android 5.1 will get below error:
Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. Check the render method of `EditProfile`.

change the example, to solve this issue
