### PR TITLE
dynamic version for react-native dependency #17

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,5 +21,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.facebook.react:react-native:0.25.+'
+    compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
This argues against doing this http://blog.danlew.net/2015/09/09/dont-use-dynamic-versions-for-your-dependencies/ but I feel this module is depending on a version of react-native that's different from the parent app , hence switching to a dynamic version makes sense.

This solves the `Could not find any version that matches com.facebook.react:react-native:0.25.+.`  as described in this ticket https://github.com/cnjon/react-native-datetime/issues/17
