### PR TITLE
Update DateTime.ios.js

### DIFF
--- a/DateTime.ios.js
+++ b/DateTime.ios.js
@@ -132,7 +132,7 @@ const _styles = StyleSheet.create({
     },
     datePicker: {
         backgroundColor: 'white',
-        alignItems: 'center',
+        //alignItems: 'center',
     },
     touchableOpacity: {
         flex: 1,


### PR DESCRIPTION
After RN0.42, add "alignItems" will cause blank page .